### PR TITLE
Add onCancel to the public interface

### DIFF
--- a/src/Future.resi
+++ b/src/Future.resi
@@ -75,6 +75,11 @@ let get: (t<'a>, 'a => unit) => unit
 let cancel: t<'a> => unit
 
 /**
+ * Adds a handler to be called if the future is canceled.
+ */
+let onCancel: (t<'a>, unit => unit) => unit
+
+/**
  * Returns a future with the value of the source future mapped
  */
 let map: (t<'a>, ~propagateCancel: bool=?, 'a => 'b) => t<'b>


### PR DESCRIPTION
This simply adds the existing onCancel function to the Future.resi public interface file.

I can discuss more why I think this is a good idea, but I thought I'd keep this quick for now.